### PR TITLE
replacing curl of current stable release from official page. The prev…

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Peevee is built using [the Rust programming language](http://www.rust-lang.org/)
 which we'll need to install so we can compile the source code:
 
 ```sh
-curl static.rust-lang.org/rustup.sh | sudo sh -- --channel=stable
+curl -sSf https://static.rust-lang.org/rustup.sh | sh
 ```
 
 When you run this command, you will need to enter your administrator password.


### PR DESCRIPTION
…ious line gave error messages without installing rust
https://www.rust-lang.org/install.html

jzh@JZHxU1404x03092014:~$ sudo curl static.rust-lang.org/rustup.sh | iconv -f windows-1251 | sudo sh -- --channel=stable
sh: 0: Can't open --channel=stable
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 41952  100 41952    0     0   320k      0 --:--:-- --:--:-- --:--:--  322k



jzh@JZHxU1404x03092014:~$ curl -sSf https://static.rust-lang.org/rustup.sh | sh

Welcome to Rust.

This script will download the Rust compiler and its package manager, Cargo, and
install them to /usr/local. You may install elsewhere by running this script
with the --prefix=<path> option.

The installer will run under 'sudo' and may ask you for your password. If you do
not want the script to run 'sudo' then pass it the --disable-sudo flag.

You may uninstall later by running /usr/local/lib/rustlib/uninstall.sh,
or by running this script again with the --uninstall flag.

Continue? (y/N) y

rustup: gpg available. signatures will be verified
rustup: downloading manifest for 'stable'
rustup: downloading toolchain for 'stable'
######################################################################## 100.0%
gpg: Signature made Wed 05 Aug 2015 03:31:43 CEST using RSA key ID 7B3B09DC
gpg: Good signature from "Rust Language (Tag and Release Signing Key) <rust-key@rust-lang.org>"
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 108F 6620 5EAE B0AA A8DD  5E1C 85AB 96E6 FA1B E5FE
     Subkey fingerprint: C134 66B7 E169 A085 1886  3216 5CB4 A934 7B3B 09DC
rustup: extracting installer
rustup: installing toolchain for 'stable'
install: creating uninstall script at /usr/local/lib/rustlib/uninstall.sh
install: installing component 'rustc'
install: installing component 'cargo'
install: installing component 'rust-docs'

    Rust is ready to roll.



jzh@JZHxU1404x03092014:~$ rustc -V
rustc 1.2.0 (082e47636 2015-08-03)

jzh@JZHxU1404x03092014:~$ cargo -V
cargo 0.4.0-nightly (15b497b 2015-07-08) (built 2015-07-10)
